### PR TITLE
Convert to objc2 ecosystem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1018,7 +1018,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
 dependencies = [
  "bitflags 2.9.1",
+ "block2",
  "dispatch2",
+ "libc",
  "objc2",
 ]
 
@@ -1060,6 +1062,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1f8e0ef3ab66b08c42644dcb34dba6ec0a574bbd8adbb8bdbdc7a2779731a44"
 dependencies = [
  "bitflags 2.9.1",
+ "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -1078,25 +1082,25 @@ checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "onepass"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "argon2",
  "char-iter",
  "clap",
- "core-foundation 0.10.1",
  "crypto-bigint",
  "home-dir",
  "keyring",
  "nom",
  "num-traits",
  "objc2",
+ "objc2-core-foundation",
  "objc2-foundation",
  "objc2-local-authentication",
+ "objc2-security",
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
  "rpassword",
- "security-framework-sys",
  "serde",
  "serde_yaml",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "onepass"
-version = "1.1.0"
+version = "1.2.0"
 categories = ["command-line-utilities"]
 edition = "2024"
 keywords = ["password", "cryptography", "deterministic"]
@@ -33,11 +33,11 @@ url = "2.5.4"
 zeroize = "1.8.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-core-foundation = "0.10.1"
 objc2 = "0.6.1"
+objc2-core-foundation = "0.3.1"
 objc2-foundation = "0.3.1"
 objc2-local-authentication = "0.3.1"
-security-framework-sys = { version = "2.14.0", features = ["OSX_10_13"] }
+objc2-security = "0.3.1"
 
 [dev-dependencies]
 num-traits = "0.2.19"

--- a/src/keyring.rs
+++ b/src/keyring.rs
@@ -24,7 +24,7 @@ const ACCOUNT: &str = "seed";
 
 pub(crate) fn load_password() -> Result<Option<Zeroizing<String>>> {
     match get_entry()?.get_password() {
-        Err(Error::NoEntry) => return Ok(None),
+        Err(Error::NoEntry) => Ok(None),
         r => Ok(Some(r?.into())),
     }
 }


### PR DESCRIPTION
I was already using objc2 for its LocalAuthentication crate; rather than proceed with a chimera of two different FFI paradigms, just standardize on objc2 since it supports everything I need.

This cleans up one or two egregious memory leaks. It also tries to zeroize passwords where appropriate in `macos_keychain`, which may or may not be at all reasonable in the first place—particularly since `SecItemCopyMatching` is documented to return `CFData` not `CFMutableData`.