### PR TITLE
Guard biometric keyring behind macos-biometry feature

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -75,6 +75,10 @@ jobs:
     - run: rustup default stable
 
     - run: cargo build --locked --profile ${{ env.profile }} --target ${{ env.target }}
+      if: !inputs.release
+    - run: cargo build -F macos-biometry --locked --profile ${{ env.profile }} --target ${{ env.target }}
+      if: inputs.release
+
     - uses: actions/upload-artifact@v4
       with:
         name: onepass-${{ env.target }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1082,7 +1082,7 @@ checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "onepass"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "onepass"
-version = "1.2.2"
+version = "1.3.0"
 categories = ["command-line-utilities"]
 edition = "2024"
 keywords = ["password", "cryptography", "deterministic"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,15 @@ exclude = [
     "example/**",
 ]
 
+[features]
+macos-biometry = [
+    "objc2",
+    "objc2-core-foundation",
+    "objc2-foundation",
+    "objc2-local-authentication",
+    "objc2-security",
+]
+
 [dependencies]
 anyhow = "1.0.98"
 argon2 = { version = "0.5.3", features = ["zeroize"] }
@@ -33,11 +42,11 @@ url = "2.5.4"
 zeroize = "1.8.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2 = "0.6.1"
-objc2-core-foundation = "0.3.1"
-objc2-foundation = "0.3.1"
-objc2-local-authentication = "0.3.1"
-objc2-security = "0.3.1"
+objc2 = { version = "0.6.1", optional = true }
+objc2-core-foundation = { version = "0.3.1", optional = true }
+objc2-foundation = { version = "0.3.1", optional = true }
+objc2-local-authentication = { version = "0.3.1", optional = true }
+objc2-security = { version = "0.3.1", optional = true }
 
 [dev-dependencies]
 num-traits = "0.2.19"

--- a/README.md
+++ b/README.md
@@ -32,29 +32,31 @@ A default config file is generated at `${XDG_CONFIG_DIR:-$HOME/.config}/onepass/
 
 ### From cargo
 
-On non-macOS platforms, onepass may be installed via cargo:
+Onepass may be installed via cargo:
 
 ```sh
 cargo install onepass
 ```
 
-### From source
+Note, however, that on macOS, the biometric keyring support will not be enabled.
 
-On non-macOS platforms, you may simply do:
+### From source
 
 ```sh
 cargo build --release &&
   sudo install target/release/onepass /usr/local/bin/onepass
 ```
 
-Building from source on macOS requires codesigning to use the biometric keychain APIs, which probably requires you to edit [`onepass.entitlements`](onepass.entitlements) to replace the team ID with your own.
+To enable the macOS biometric keyring support, you will need to produce a codesigned binary.
+
+To do this, you will probably need to edit [`onepass.entitlements`](onepass.entitlements) to replace the team ID with your own.
 
 Assuming you’re using an Apple Development local-only signing key, you should be able to do something like the following:
 
 ```sh
 sed "s/2TM4K8523U.org.whilezero.app.onepass/$MY_TEAM_ID.*/" \
     onepass.entitlements > my-onepass.entitlements &&
-  cargo build --release &&
+  cargo build -F macos-biometry --release &&
   codesign \
     --force \
     --options runtime \

--- a/build.rs
+++ b/build.rs
@@ -55,9 +55,10 @@ fn main() -> Result<()> {
 
     println!("cargo:rerun-if-changed=eff_large_wordlist.txt");
 
-    // Embed Info.plist on macOS
+    // Embed Info.plist on macOS with macos-biometry feature
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
-    if target_os == "macos" {
+    let macos_biometry = env::var("CARGO_FEATURE_MACOS_BIOMETRY").is_ok();
+    if target_os == "macos" && macos_biometry {
         println!("cargo:rustc-link-arg=-Wl,-sectcreate,__TEXT,__info_plist,Info.plist");
         println!("cargo:rerun-if-changed=Info.plist");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@
 mod config;
 mod crypto;
 mod seed_password;
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", feature = "macos-biometry"))]
 mod macos_keychain;
 mod randexp;
 mod url;

--- a/src/seed_password.rs
+++ b/src/seed_password.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", feature = "macos-biometry"))]
 use crate::macos_keychain::{Entry, Error};
 use anyhow::{Context, Result};
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(all(target_os = "macos", feature = "macos-biometry")))]
 use keyring::{Entry, Error};
 use rpassword::prompt_password;
 use zeroize::Zeroizing;


### PR DESCRIPTION
Rather than unconditionally using the biometric keyring code on macOS, this guards it behind a new `macos-biometry` feature, allowing macOS builds to be built with normal Keychain Access support if the feature is not enabled.