### PR TITLE
Switch from setup-rust-toolchain to plain rustup

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -87,12 +87,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         ref: ${{ inputs.tag || github.ref }}
-    - uses: actions-rust-lang/setup-rust-toolchain@v1
-      if: ${{ matrix.runner == 'windows-11-arm' }}
-      with:
-        toolchain: ${{ env.RUST_VERSION }}
     - uses: actions/cache@v4
-      if: ${{ matrix.runner != 'windows-11-arm' }}
       with:
         path: |
           ~/.cargo/git
@@ -103,10 +98,8 @@ jobs:
         restore-keys: |
           rust-${{ env.target }}-${{ env.profile }}-
     - run: rustup toolchain install ${{ env.RUST_VERSION }} --target ${{ env.target }} --profile minimal
-      if: ${{ matrix.runner != 'windows-11-arm' }}
       shell: bash
     - run: rustup default ${{ env.RUST_VERSION }}
-      if: ${{ matrix.runner != 'windows-11-arm' }}
 
     - run: cargo build --locked --profile ${{ env.profile }} --target ${{ env.target }}
       if: ${{ env.biometry != 'true' }}


### PR DESCRIPTION
I started using `actions-rust-lang/setup-rust-toolchain` because `rustup` was not working on the `windows-11-arm` runners a little while ago. Now, `rustup` does seem to be working, so we no longer need to pay the complexity cost of that action, its dependencies, and homebrew for our GitHub workflows.