### PR TITLE
Default use_keyring to false on Linux

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -169,7 +169,7 @@ impl SerConfig {
         })
         .collect();
         let default_schema = "login".to_string();
-        let use_keyring = Some(true);
+        let use_keyring = Some(cfg!(not(target_os = "linux")));
         SerConfig {
             words_path: None,
             default_schema,


### PR DESCRIPTION
gnome-keyring is not reliably installed on Linux; let users opt in to it.