### PR TITLE
Use forked rust-cache action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -91,19 +91,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         ref: ${{ inputs.tag || github.ref }}
-    - uses: actions/cache@v4
-      with:
-        path: |
-          ~/.cargo/git
-          ~/.cargo/registry
-          target
-        key:
-          rust-${{ env.target }}-${{ env.profile }}-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          rust-${{ env.target }}-${{ env.profile }}-
     - run: rustup toolchain install ${{ env.RUST_VERSION }} --target ${{ env.target }} --profile minimal
       shell: bash
     - run: rustup default ${{ env.RUST_VERSION }}
+    - uses: mrdomino/rust-cache@v2
 
     - run: cargo build --locked --profile ${{ env.profile }} --target ${{ env.target }}${{ env.features }}
 


### PR DESCRIPTION
Uses the more intelligent caching from [Swatinem/rust-cache][0], but from our own fork so we do not need to worry as much about software supply chain attacks on the workflow.

[0]: https://github.com/Swatinem/rust-cache