### PR TITLE
Fix schema interpolation in included configs

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -85,6 +85,10 @@ impl Config {
             .into_iter()
             .for_each(|v| self.use_keyring = Some(v));
         self.aliases.extend(mem::take(&mut other.aliases));
+        // TODO(someday): merge and apply schema aliases in a more principled way.
+        // This only applies base schemas to included sites; it does not apply included schemas
+        // to base sites. To do the latter seems like it would require a more substantial rework
+        // of the schema alias code.
         for (k, mut config) in other.sites.into_iter() {
             if let Some(schema) = self.aliases.get(&config.schema) {
                 config.schema = schema.clone();


### PR DESCRIPTION
This applies base schemas to included sites, but not included schemas to base sites. To do the latter would require a more substantial rework, and currently seems of limited use; I’ll get to it at some point unless someone submits a PR first.