### PR TITLE
Bump rust toolchain from 1.89 to 1.90

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,9 +17,6 @@ on:
         type: string
         required: false
 
-env:
-  RUST_VERSION: "1.90"
-
 jobs:
   build:
     name: Build
@@ -94,9 +91,7 @@ jobs:
     - uses: actions/checkout@v5
       with:
         ref: ${{ inputs.tag || github.ref }}
-    - run: rustup toolchain install ${{ env.RUST_VERSION }} --target ${{ env.target }} --profile minimal
-      shell: bash
-    - run: rustup default ${{ env.RUST_VERSION }}
+    - run: rustup toolchain install --target ${{ env.target }} --profile minimal
     - uses: mrdomino/rust-cache@v2
       with:
         key: ${{ env.profile }}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.90"


### PR DESCRIPTION
Also moves this configuration out of the build workflow and into `rust-toolchain.toml`, so the same settings will apply locally and in CI.