### PR TITLE
Fix zizmor findings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,12 @@ updates:
       interval: "daily"
     target-branch: v3-dev
     labels: ["dependencies", "v3-dev"]
+    cooldown:
+      default-days: 14
+      exclude:
+        - argon2
+        - blake2
+        - crypto-bigint
 
   - package-ecosystem: "cargo"
     directory: "/"
@@ -13,15 +19,21 @@ updates:
       interval: "daily"
     target-branch: main
     labels: ["dependencies", "main"]
+    cooldown:
+      default-days: 28
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     target-branch: main
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     target-branch: v3-dev
+    cooldown:
+      default-days: 7

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,6 +14,9 @@ on:
         type: string
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build
@@ -89,12 +92,14 @@ jobs:
       with:
         ref: ${{ inputs.tag || github.ref }}
         persist-credentials: false
-    - run: rustup toolchain install --target ${{ env.target }} --profile minimal
+    - run: | # zizmor: ignore[template-injection]
+        rustup toolchain install --target ${{ env.target }} --profile minimal
     - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
         key: ${{ env.profile }}
 
-    - run: cargo build --locked --profile ${{ env.profile }} --target ${{ env.target }}${{ env.features }}
+    - run: | # zizmor: ignore[template-injection]
+        cargo build --locked --profile ${{ env.profile }} --target ${{ env.target }}${{ env.features }}
 
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
@@ -102,5 +107,6 @@ jobs:
         path: target/${{ env.target }}/${{ env.outdir }}/onepass${{ env.suffix }}
         retention-days: ${{ env.retention_days }}
 
-    - run: cargo test --profile dev --target ${{ env.target }} -- --include-ignored
+    - run: | # zizmor: ignore[template-injection]
+        cargo test --profile dev --target ${{ env.target }} -- --include-ignored
       if: ${{ !inputs.release }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -85,17 +85,18 @@ jobs:
         EOF
       if: ${{ matrix.os == 'ubuntu' }}
 
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         ref: ${{ inputs.tag || github.ref }}
+        persist-credentials: false
     - run: rustup toolchain install --target ${{ env.target }} --profile minimal
-    - uses: mrdomino/rust-cache@v2
+    - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
         key: ${{ env.profile }}
 
     - run: cargo build --locked --profile ${{ env.profile }} --target ${{ env.target }}${{ env.features }}
 
-    - uses: actions/upload-artifact@v7
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: onepass-${{ env.target }}
         path: target/${{ env.target }}/${{ env.outdir }}/onepass${{ env.suffix }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,9 +34,10 @@ jobs:
     environment: crates-io
     if: startsWith(github.ref, 'refs/tags/v') || inputs.publish
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         ref: ${{ inputs.tag || github.ref }}
+        persist-credentials: false
     - name: install system dependencies
       run: |
         sudo sh -eu <<EOF
@@ -44,7 +45,7 @@ jobs:
             libbsd-dev \
             libdbus-1-dev
         EOF
-    - uses: rust-lang/crates-io-auth-action@v1
+    - uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1
       id: auth
     - name: publish base
       working-directory: crates/base
@@ -72,10 +73,11 @@ jobs:
     runs-on: macos-latest
     environment: macos
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         ref: ${{ inputs.tag || github.ref }}
-    - uses: actions/download-artifact@v8
+        persist-credentials: false
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: onepass-aarch64-apple-darwin
     - name: Install Apple certificate
@@ -120,7 +122,7 @@ jobs:
             .root/onepass
         chmod +x .root/onepass
 
-    - uses: actions/upload-artifact@v7
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: onepass-signed-darwin
         path: .root/onepass
@@ -131,8 +133,8 @@ jobs:
     - name: get version
       id: get-version
       run: |
-        if [ -n "${{ inputs.tag }}" ]; then
-          expected_version="${{ inputs.tag }}"
+        if [ -n "${INPUTS_TAG}" ]; then
+          expected_version="${INPUTS_TAG}"
         else
           expected_version="${GITHUB_REF#refs/tags/}"
         fi
@@ -141,11 +143,14 @@ jobs:
         expected_clean="${expected_version#v}"
 
         echo "version=$expected_clean" >> $GITHUB_OUTPUT
+      env:
+        INPUTS_TAG: ${{ inputs.tag }}
 
     - name: notarize installer
       env:
         NOTARY_PASS: ${{ secrets.NOTARY_PASS }}
         DEV_ACCOUNT: ${{ secrets.DEV_ACCOUNT }}
+        STEPS_GET_VERSION_OUTPUTS_VERSION: ${{ steps.get-version.outputs.version }}
       run: |
         set -xuo pipefail
         xcrun notarytool store-credentials \
@@ -155,7 +160,7 @@ jobs:
             notary-onepass
         pkgbuild --root .root \
                  --identifier org.wholezero.pkg.onepass \
-                 --version "${{ steps.get-version.outputs.version }}" \
+                 --version "${STEPS_GET_VERSION_OUTPUTS_VERSION}" \
                  --install-location /usr/local/bin \
                  --sign "Developer ID Installer: Steven Dee (2TM4K8523U)" \
                  onepass.pkg
@@ -168,7 +173,7 @@ jobs:
         xcrun stapler staple onepass.pkg
         spctl --assess -vv --type install onepass.pkg
 
-    - uses: actions/upload-artifact@v7
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: onepass-pkg-darwin
         path: onepass.pkg
@@ -182,7 +187,7 @@ jobs:
     needs: [build, macos-release]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/download-artifact@v8
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         path: artifacts
     - run: |
@@ -191,7 +196,7 @@ jobs:
         for path in artifacts/*; do
           mv "$path"/onepass* "attest/${path#artifacts/}"
         done
-    - uses: actions/attest-build-provenance@v4
+    - uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
       with:
         subject-path: attest/*
 
@@ -203,20 +208,23 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v') || inputs.create_github_release
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         ref: ${{ inputs.tag || github.ref }}
+        persist-credentials: false
 
     - name: Get version
       id: get-version
       run: |
-        if [ -n "${{ inputs.tag }}" ]; then
-          echo "version=${{ inputs.tag }}" >> $GITHUB_OUTPUT
+        if [ -n "${INPUTS_TAG}" ]; then
+          echo "version=${INPUTS_TAG}" >> $GITHUB_OUTPUT
         else
           echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
         fi
+      env:
+        INPUTS_TAG: ${{ inputs.tag }}
 
-    - uses: actions/download-artifact@v8
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         path: artifacts
 
@@ -238,7 +246,7 @@ jobs:
         cp onepass.provisionprofile release-files/
 
     - name: Create Release
-      uses: softprops/action-gh-release@v3
+      uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
       with:
         draft: true
         tag_name: ${{ steps.get-version.outputs.version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,8 @@ on:
         type: boolean
         default: false
 
+permissions: {}
+
 jobs:
   build:
     uses: ./.github/workflows/build.yaml
@@ -28,6 +30,7 @@ jobs:
   publish:
     name: Publish to crates.io
     permissions:
+      contents: read
       id-token: write
     needs: build
     runs-on: ubuntu-latest
@@ -246,10 +249,12 @@ jobs:
         cp onepass.provisionprofile release-files/
 
     - name: Create Release
-      uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
-      with:
-        draft: true
-        tag_name: ${{ steps.get-version.outputs.version }}
-        name: Release ${{ steps.get-version.outputs.version }}
-        files: release-files/*
-        generate_release_notes: true
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        VERSION: ${{ steps.get-version.outputs.version }}
+      run: |
+        gh release create "$VERSION" \
+          --draft \
+          --title "Release $VERSION" \
+          --generate-notes \
+          release-files/*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,9 @@ permissions: {}
 
 jobs:
   build:
+    name: Build
+    permissions:
+      contents: read
     uses: ./.github/workflows/build.yaml
     with:
       release: true


### PR DESCRIPTION
Put dependabot cooldowns in place with some tweaks:
- I trust RustCrypto (and am waiting on a couple packages to have stable releases)
- The crates ecosystem is bigger and I use rarer crates, so use a longer cooldown period here
- Use an even longer cooldown period for v2 since it’s stable and rarely moves

Switched from my own fork of rust-cache to upstream now that I’m pinning its hash.